### PR TITLE
Styling fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,6 @@
       <TheErrorModal :display="mapError" />
       <TheMap />
       <TheConsole v-if="mapLoaded" />
-      <DatePicker v-if="mapLoaded" />
       <TheTimelapse v-if="mapLoaded" />
     </v-app>
   </div>
@@ -19,8 +18,7 @@ import TheErrorModal from "./components/TheErrorModal";
 import TheMap from "./components/TheMap";
 import TheProgressCircle from "./components/TheProgressCircle";
 import TheWarningAlert from "./components/TheWarningAlert";
-import DatePicker from "./components/timelapse/DatePicker.vue";
-import TheTimelapse from "./components/timelapse/TheTimelapse"
+import TheTimelapse from "./components/timelapse/TheTimelapse";
 
 export default {
   name: "app",
@@ -30,7 +28,6 @@ export default {
     TheMap,
     TheProgressCircle,
     TheWarningAlert,
-    DatePicker,
     TheTimelapse
   },
   data() {

--- a/src/components/timelapse/DatePicker.vue
+++ b/src/components/timelapse/DatePicker.vue
@@ -6,7 +6,7 @@
         id="datepicker-trigger"
         placeholder="Select dates"
         :value="formatDates(dateOne, dateTwo)"
-      >
+      />
 
       <AirbnbStyleDatepicker
         :offset-y="-270"
@@ -15,137 +15,43 @@
         :fullscreen-mobile="true"
         :date-one="dateOne"
         :date-two="dateTwo"
-        @date-one-selected="val => { dateOne = val }"
-        @date-two-selected="val => { dateTwo = val }"
+        @date-one-selected="
+          val => {
+            dateOne = val;
+          }
+        "
+        @date-two-selected="
+          val => {
+            dateTwo = val;
+          }
+        "
       />
     </div>
   </div>
 </template>
 
 <script>
-import format from 'date-fns/format'
+import format from "date-fns/format";
 
 export default {
   data() {
     return {
-      dateFormat: 'D MMM',
-      dateOne: '',
-      dateTwo: ''
-    }
+      dateFormat: "D MMM",
+      dateOne: "",
+      dateTwo: ""
+    };
   },
   methods: {
     formatDates(dateOne, dateTwo) {
-      let formattedDates = ''
+      let formattedDates = "";
       if (dateOne) {
-        formattedDates = format(dateOne, this.dateFormat)
+        formattedDates = format(dateOne, this.dateFormat);
       }
       if (dateTwo) {
-        formattedDates += ' - ' + format(dateTwo, this.dateFormat)
+        formattedDates += " - " + format(dateTwo, this.dateFormat);
       }
-      return formattedDates
+      return formattedDates;
     }
   }
-}
-</script>
-
-<style>
- .datepicker-trigger {
-    position: fixed;
-    margin: 600px 0 0 90px;
-    z-index: 1;
-
- }
-</style>
-
-
-
-
-<!-- <template>
-    <div id="datepicker">
-
-        <v-layout row wrap>
-            <v-flex justify-space-around xs4 sm2>
-                <v-icon x-large color="teal">event</v-icon>
-            </v-flex>
-
-            <v-flex xs4 sm4>
-                <v-menu
-                ref="menu"
-                v-model="menu"
-                :return-value.sync="startdate"
-                :close-on-content-click="false"
-                transition="scale-transition"
-
-                >
-                    <v-text-field
-                    slot="activator"
-                    v-model="startdate"
-                    label="Start date"
-                    readonly
-                  ></v-text-field>
-                  <v-date-picker v-model="startdate">
-                    <v-spacer></v-spacer>
-                    <v-btn flat color="primary" @click="menu = false">Cancel</v-btn>
-                    <v-btn flat color="primary" @click="$refs.menu.save(startdate)">OK</v-btn>
-                  </v-date-picker>
-                </v-menu>
-            </v-flex>
-            <v-flex xs4 sm4>
-                <v-menu
-                ref="menu1"
-                v-model="menu1"
-                :return-value.sync="enddate"
-                :close-on-content-click="false"
-                transition="scale-transition"
-                >
-                    <v-text-field
-                    slot="activator"
-                    v-model="enddate"
-                    label="End date"
-                    readonly
-                  ></v-text-field>
-                  <v-date-picker v-model="enddate">
-                    <v-spacer></v-spacer>
-                    <v-btn flat color="primary" @click="menu1 = false">Cancel</v-btn>
-                    <v-btn flat color="primary" @click="$refs.menu1.save(enddate)">OK</v-btn>
-                  </v-date-picker>
-                </v-menu>
-            </v-flex>
-
-        </v-layout>
-    </div>
-</template>
-
-
-<script>
-export default {
-    data() {
-        return {
-            startdate: new Date().toISOString().substr(0, 10),
-            menu: false,
-            enddate: new Date().toISOString().substr(0, 10),
-            menu1: false
-
-        };
-    }
-
 };
-
 </script>
-
-
-
-<style>
-#datepicker {
-    position: fixed;
-    margin: 590px 0 0 10px;
-}
-
-/*.v-input__icon--prepend .v-icon {
-    font-size: 35px;
-    color: teal;
-}*/
-
-
-
-</style> -->

--- a/src/components/timelapse/PlayButton.vue
+++ b/src/components/timelapse/PlayButton.vue
@@ -1,49 +1,29 @@
 <template>
-  <div id = "button">
-    <v-btn
-      color='teal'
-      dark
-      depressed
-      @click="toggle"
-    >
-      <v-icon
-        v-if="isPlaying"
-      >pause</v-icon>
-      <v-icon
-        v-else
-      >play_arrow</v-icon>
-    </v-btn>
-  </div>
+  <v-btn color="teal" dark depressed @click="toggle">
+    <v-icon v-if="isPlaying">pause</v-icon>
+    <v-icon v-else>play_arrow</v-icon>
+  </v-btn>
 </template>
 <script>
 import { eventBus } from "@/main";
 export default {
-  data () {
+  data() {
     return {
       isPlaying: false
-    }
+    };
   },
 
   methods: {
-    toggle () {
-      this.isPlaying = !this.isPlaying
-      eventBus.$emit("toggle-timelapse", this.isPlaying)
+    toggle() {
+      this.isPlaying = !this.isPlaying;
+      eventBus.$emit("toggle-timelapse", this.isPlaying);
     }
   }
-}
+};
 </script>
 <style scoped>
 .v-btn {
-  min-width: 0; /*had to override some properties of v-btn to make it square*/
-  min-height: 50px;
-}
-#button {
-  position: fixed;
-  bottom: 11px;
-  left: 205px;
-  margin: 10px;
-  padding: 10px;
-  border-radius: 3px;
-  z-index: 0;
+  min-width: 0px;
+  height: 50px;
 }
 </style>

--- a/src/components/timelapse/PlayButton.vue
+++ b/src/components/timelapse/PlayButton.vue
@@ -23,7 +23,8 @@ export default {
 </script>
 <style scoped>
 .v-btn {
-  min-width: 0px;
-  height: 50px;
+  min-width: 0px; /* had to override some properties of v-btn to make it square */
+  min-height: 50px;
+  border-radius: 3px;
 }
 </style>

--- a/src/components/timelapse/TheTimelapse.vue
+++ b/src/components/timelapse/TheTimelapse.vue
@@ -1,23 +1,33 @@
 <template>
-  <div id = "timelapse">
-    <PlayButton v-if = "timelapseMode" />
-    <TimelapseBar v-if = "timelapseMode" />
+  <div id="timelapse">
+    <DatePicker />
+    <PlayButton />
+    <TimelapseBar />
   </div>
 </template>
 
 <script>
-import TimelapseBar from "./TimelapseBar"
-import PlayButton from "./PlayButton"
+import DatePicker from "./DatePicker";
+import PlayButton from "./PlayButton";
+import TimelapseBar from "./TimelapseBar";
 
 export default {
-  data () {
-    return {
-      timelapseMode: true //whether or not the map is in timelapse mode
-    }
-  },
   components: {
-    TimelapseBar,
-    PlayButton
+    DatePicker,
+    PlayButton,
+    TimelapseBar
   }
-}
+};
 </script>
+
+<style scoped>
+#timelapse {
+  position: absolute;
+  bottom: 32px;
+  left: 85px;
+}
+
+#timelapse > * {
+  display: inline-block;
+}
+</style>

--- a/src/components/timelapse/TimelapseBar.vue
+++ b/src/components/timelapse/TimelapseBar.vue
@@ -90,12 +90,8 @@ export default {
 <style scoped>
 #bar {
   position: fixed;
-  bottom: 84px;
-  right: 60px;
-  left: 310px;
-  height: 0px;
-  margin: 10px;
-  border-radius: 3px;
-  z-index: 0;
+  right: 70px;
+  left: 315px;
+  margin-left: 10px;
 }
 </style>


### PR DESCRIPTION
1. Use `DatePicker` in `TheTimelapse` component.
2. Simplified styling of timelapse components by positioning their parent - `div#timelapse`. It also fixes some weird ambigiuties that were taking place, for example, `div#timelapse` and `div#bar` earlier had heights of zero, which doesn't make sense since they both contain elements with non-zero height. 
3. It seems `z-index` doesn't explicitly need to be specified - the components appear in the stack as they are intended.
4. Removed `timelapseMode` - we have decided that the date selection and the bar will always be present.
5. Also ran `prettier` through most of the files.
6. Deleted some commented out code in `DatePicker.vue` - we can always recover that code if required.